### PR TITLE
Add build option for linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
       "icon": "static/icons/icon.ico"
     },
     "linux": {
+      "category": "Utility",
       "icon": "static/icons"
     }
   },


### PR DESCRIPTION
これがないとlinux上でbuildできません。

値については`Utility`で正しいのかよくわかりませんがとりあえず。
ref. https://specifications.freedesktop.org/menu-spec/latest/apa.html#main-category-registry